### PR TITLE
Replace flags with environment variables

### DIFF
--- a/cmd/retry/usage.tmpl
+++ b/cmd/retry/usage.tmpl
@@ -1,18 +1,28 @@
-Usage:
-  {{ .Name }} [{{ .Name }} flags] [--] command [command flags] [command arguments] [...]
+Tool to retry a command in case it fails.
 
-Flags:
-{{ .Flags }}
-  Note: {{ .Name }} uses a back-off style delay, this means that the
-        delay is slighly increased with each attempt.
+Usage:
+  {{ .Name }} command [command flags] [command arguments] [...]
+
+Note: {{ .Name }} uses a back-off style delay, this means that the
+      delay is slightly increased with each attempt.
+
+Environment Variables:
+  {{ printf "%-16s %s" .EnvVarAttempts "Number of attempts" }}
+  {{ printf "%-16s %s" .EnvVarDelay "Initial delay between attempts" }}
+  {{ printf "%-16s %s" .EnvVarBeQuiet "Disable output for failed attempts" }}
 
 Examples:
   Run curl command with default settings ({{ .Attempts }} attempts with an initial delay of {{ .Delay }}):
   $ {{ .Name }} curl wttr.in
 
   Specify the number of attempts (retries):
-  $ {{ .Name }} --attempts 5 -- some-command --flag
+  $ export {{ .EnvVarAttempts }}=5
+  $ {{ .Name }} some-command --flag
 
-  Use a custom initial delay:
-  $ {{ .Name }} --delay 100ms -- some-command
+  Use a custom initial delay of 125ms:
+  $ export {{ .EnvVarDelay }}=125ms
+  $ {{ .Name }} some-command
+
+Version:
+  {{ .Version }}
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/avast/retry-go/v4 v4.1.0
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.0
-	github.com/spf13/pflag v1.0.5
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 )
 

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0/go.mod h1:4xpM
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/robertkrimen/godocdown v0.0.0-20130622164427-0bfa04905481/go.mod h1:C9WhFzY47SzYBIvzFqSvHIR6ROgDo4TtdTuRaOMjF/s=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
Since the usage and parsing of tool flags and command flags could easily
interfere, the command line flags are replaced with environment variables.
